### PR TITLE
Add BLS signature functionality to shcrypto

### DIFF
--- a/shlib/shcrypto/signatures.go
+++ b/shlib/shcrypto/signatures.go
@@ -1,0 +1,78 @@
+package shcrypto
+
+import (
+	"io"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	bn256 "github.com/ethereum/go-ethereum/crypto/bn256/cloudflare"
+)
+
+type (
+	BLSSecretKey *big.Int
+	BLSPublicKey *bn256.G1
+	BLSSignature *bn256.G2
+)
+
+// RandomBLSKeyPair generates a random BLS secret and corresponding public key.
+func RandomBLSKeyPair(r io.Reader) (BLSSecretKey, BLSPublicKey, error) {
+	i, g1, err := bn256.RandomG1(r)
+	if err != nil {
+		return nil, nil, err
+	}
+	return BLSSecretKey(i), BLSPublicKey(g1), nil
+}
+
+// BLSSecretToPublicKey returns the BLS public key corresponding to the given secret key.
+func BLSSecretToPublicKey(secretKey BLSSecretKey) BLSPublicKey {
+	return BLSPublicKey(new(bn256.G1).ScalarBaseMult(secretKey))
+}
+
+// BLSSign creates a signature over a message using a secret key.
+func BLSSign(msg []byte, secretKey BLSSecretKey) BLSSignature {
+	h := hashToG2(msg)
+	sig := new(bn256.G2).ScalarMult(h, secretKey)
+	return BLSSignature(sig)
+}
+
+// BLSVerify checks that a signature over a certain message was created with the secret key
+// corresponding to the given public key.
+func BLSVerify(sig BLSSignature, publicKey BLSPublicKey, msg []byte) bool {
+	h := hashToG2(msg)
+	g1 := new(bn256.G1).ScalarBaseMult(big.NewInt(1))
+	return bn256.PairingCheck(
+		[]*bn256.G1{
+			new(bn256.G1).Neg(g1),
+			publicKey,
+		},
+		[]*bn256.G2{
+			sig,
+			h,
+		},
+	)
+}
+
+// BLSAggregateSignatures aggregates a set of BLS signatures into one.
+func BLSAggregateSignatures(sigs []BLSSignature) BLSSignature {
+	aggSig := new(bn256.G2).ScalarBaseMult(big.NewInt(0))
+	for _, sig := range sigs {
+		aggSig.Add(aggSig, sig)
+	}
+	return BLSSignature(aggSig)
+}
+
+// BLSAggregatePublicKeys aggregates a set of BLS public keys into one.
+func BLSAggregatePublicKeys(publicKeys []BLSPublicKey) BLSPublicKey {
+	aggPublicKey := new(bn256.G1).ScalarBaseMult(big.NewInt(0))
+	for _, publicKey := range publicKeys {
+		aggPublicKey.Add(aggPublicKey, publicKey)
+	}
+	return BLSPublicKey(aggPublicKey)
+}
+
+func hashToG2(data []byte) *bn256.G2 {
+	// FIXME: use proper hash to curve algorithm
+	// see https://github.com/shutter-network/rolling-shutter/issues/38
+	h := crypto.Keccak256Hash(data)
+	return new(bn256.G2).ScalarBaseMult(h.Big())
+}

--- a/shlib/shcrypto/signatures_test.go
+++ b/shlib/shcrypto/signatures_test.go
@@ -1,0 +1,67 @@
+package shcrypto
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestSigning(t *testing.T) {
+	secretKey, publicKey, err := RandomBLSKeyPair(rand.Reader)
+	assert.NilError(t, err)
+
+	msg := []byte("hello")
+	sig := BLSSign(msg, secretKey)
+	assert.Check(t, BLSVerify(sig, publicKey, msg))
+
+	secretKey2, publicKey2, err := RandomBLSKeyPair(rand.Reader)
+	assert.NilError(t, err)
+	sig2 := BLSSign(msg, secretKey2)
+
+	assert.Check(t, !BLSVerify(sig, publicKey, []byte("good bye")))
+	assert.Check(t, !BLSVerify(sig, publicKey2, msg))
+	assert.Check(t, !BLSVerify(sig2, publicKey, msg))
+}
+
+func TestAggregation(t *testing.T) {
+	msg := []byte("hello")
+
+	allsecretKeys := []BLSSecretKey{}
+	allPublicKeys := []BLSPublicKey{}
+	allSigs := []BLSSignature{}
+	for i := 0; i < 3; i++ {
+		secretKey, publicKey, err := RandomBLSKeyPair(rand.Reader)
+		assert.NilError(t, err)
+		sig := BLSSign(msg, secretKey)
+
+		allsecretKeys = append(allsecretKeys, secretKey)
+		allPublicKeys = append(allPublicKeys, publicKey)
+		allSigs = append(allSigs, sig)
+	}
+
+	combinations := [][]int{
+		{0, 1},
+		{1, 2},
+		{0, 2},
+		{0, 1, 2},
+	}
+
+	for _, signers := range combinations {
+		secretKeys := []BLSSecretKey{}
+		publicKeys := []BLSPublicKey{}
+		sigs := []BLSSignature{}
+		for _, signer := range signers {
+			secretKeys = append(secretKeys, allsecretKeys[signer])
+			publicKeys = append(publicKeys, allPublicKeys[signer])
+			sigs = append(sigs, allSigs[signer])
+		}
+
+		aggPublicKey := BLSAggregatePublicKeys(publicKeys)
+		aggSig := BLSAggregateSignatures(sigs)
+		assert.Check(t, BLSVerify(aggSig, aggPublicKey, msg))
+		assert.Check(t, !BLSVerify(aggSig, aggPublicKey, []byte("good bye")))
+		assert.Check(t, !BLSVerify(aggSig, allPublicKeys[0], msg))
+		assert.Check(t, !BLSVerify(allSigs[0], aggPublicKey, msg))
+	}
+}


### PR DESCRIPTION
As opposed to most other libraries I found, it uses `G1` for public keys to allow for cheap aggregation of public keys on Ethereum. It is based on the `bn256` package used in `go-ethereum` for the precompiles.