### PR TITLE
Prepare shcrypto to be compiled with tinygo

### DIFF
--- a/shlib/go.mod
+++ b/shlib/go.mod
@@ -6,13 +6,13 @@ require (
 	github.com/ethereum/go-ethereum v1.10.8
 	github.com/google/go-cmp v0.5.6
 	github.com/pkg/errors v0.9.1
+	golang.org/x/crypto v0.0.0-20210506145944-38f3c27a63bf
 	gotest.tools v2.2.0+incompatible
 	gotest.tools/v3 v3.0.3
 )
 
 require (
 	github.com/btcsuite/btcd v0.22.0-beta // indirect
-	golang.org/x/crypto v0.0.0-20210506145944-38f3c27a63bf // indirect
 	golang.org/x/sys v0.0.0-20210816183151-1e6c022a8912 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/shlib/shcrypto/encoding.go
+++ b/shlib/shcrypto/encoding.go
@@ -2,10 +2,11 @@ package shcrypto
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"math/big"
 
 	bn256 "github.com/ethereum/go-ethereum/crypto/bn256/cloudflare"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -39,10 +40,10 @@ func (m *EncryptedMessage) Unmarshal(d []byte) error {
 		return err
 	}
 	if len(d)%BlockSize != 0 {
-		return errors.Errorf("length not a multiple of %d", BlockSize)
+		return fmt.Errorf("length not a multiple of %d", BlockSize)
 	}
 	if len(d) < BlockSize {
-		return errors.Errorf("short block")
+		return fmt.Errorf("short block")
 	}
 	copy(m.C2[:], d)
 	d = d[BlockSize:]

--- a/shlib/shcrypto/encoding_test.go
+++ b/shlib/shcrypto/encoding_test.go
@@ -30,7 +30,7 @@ func TestMarshalUnmarshal(t *testing.T) {
 	m2 := &EncryptedMessage{}
 	err := m2.Unmarshal(m1.Marshal())
 	assert.NilError(t, err)
-	assert.DeepEqual(t, m1, m2, G2Comparer)
+	assert.DeepEqual(t, m1, m2, g2Comparer)
 }
 
 func TestUnmarshalBroken(t *testing.T) {

--- a/shlib/shcrypto/encryption.go
+++ b/shlib/shcrypto/encryption.go
@@ -3,12 +3,13 @@ package shcrypto
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
+	"fmt"
 	"io"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	bn256 "github.com/ethereum/go-ethereum/crypto/bn256/cloudflare"
-	"github.com/pkg/errors"
 )
 
 // EncryptedMessage represents the full output of the encryption procedure.
@@ -60,7 +61,7 @@ func RandomSigma(r io.Reader) (Block, error) {
 	data := make([]byte, BlockSize)
 	_, err := r.Read(data)
 	if err != nil {
-		return Block{}, errors.WithStack(err)
+		return Block{}, err
 	}
 	var b Block
 	copy(b[:], data)
@@ -169,10 +170,10 @@ func UnpadMessage(blocks []Block) ([]byte, error) {
 	lastBlock := blocks[len(blocks)-1]
 	paddingLength := int(lastBlock[BlockSize-1])
 	if paddingLength == 0 {
-		return nil, errors.Errorf("invalid padding length 0")
+		return nil, errors.New("invalid padding length 0")
 	}
 	if paddingLength > BlockSize {
-		return nil, errors.Errorf("invalid padding length %d (greater than block size %d)", paddingLength, BlockSize)
+		return nil, fmt.Errorf("invalid padding length %d (greater than block size %d)", paddingLength, BlockSize)
 	}
 
 	m := make([]byte, len(blocks)*BlockSize-paddingLength)

--- a/shlib/shcrypto/encryption.go
+++ b/shlib/shcrypto/encryption.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/crypto"
 	bn256 "github.com/ethereum/go-ethereum/crypto/bn256/cloudflare"
 )
 
@@ -24,28 +23,6 @@ type Block [BlockSize]byte
 
 // BlockSize is the size in bytes of the blocks into which a message is split up before encryption.
 const BlockSize = 32
-
-// HashBytesToBlock hashes the given byte slice and returns the result as a block.
-func HashBytesToBlock(d ...[]byte) Block {
-	h := crypto.Keccak256(d...)
-	var b Block
-	copy(b[:], h)
-	return b
-}
-
-// HashBlockToInt hashes a block and returns the result as an integer in Z_q.
-func HashBlockToInt(d Block) *big.Int {
-	h := crypto.Keccak256(d[:])
-	i := new(big.Int).SetBytes(h)
-	i.Mod(i, bn256.Order) // TODO: check if this is fine
-	return i
-}
-
-// HashGTToBlock hashes an element of GT and returns the result as a block.
-func HashGTToBlock(gt *bn256.GT) Block {
-	b := gt.Marshal()
-	return HashBytesToBlock(b)
-}
 
 // XORBlocks xors the two blocks and returns the result.
 func XORBlocks(b1 Block, b2 Block) Block {

--- a/shlib/shcrypto/encryption_test.go
+++ b/shlib/shcrypto/encryption_test.go
@@ -231,7 +231,7 @@ func TestRoundTrip(t *testing.T) {
 		epochSecretKeyShares = append(epochSecretKeyShares, ComputeEpochSecretKeyShare(eonSecretKeyShares[i], epochID))
 	}
 	eonPublicKey := ComputeEonPublicKey(gammas)
-	assert.DeepEqual(t, new(bn256.G2).ScalarBaseMult(eonSecretKey), (*bn256.G2)(eonPublicKey), G2Comparer)
+	assert.DeepEqual(t, new(bn256.G2).ScalarBaseMult(eonSecretKey), (*bn256.G2)(eonPublicKey), g2Comparer)
 	epochSecretKey, err := ComputeEpochSecretKey(
 		[]int{0, 1},
 		[]*EpochSecretKeyShare{epochSecretKeyShares[0], epochSecretKeyShares[1]},

--- a/shlib/shcrypto/feldman.go
+++ b/shlib/shcrypto/feldman.go
@@ -3,12 +3,12 @@ package shcrypto
 import (
 	"bytes"
 	"crypto/rand"
+	"fmt"
 	"io"
 	"math/big"
 
 	bn256 "github.com/ethereum/go-ethereum/crypto/bn256/cloudflare"
 	gocmp "github.com/google/go-cmp/cmp"
-	"github.com/pkg/errors"
 )
 
 var (
@@ -31,14 +31,14 @@ func init() {
 // range of them.
 func NewPolynomial(coefficients []*big.Int) (*Polynomial, error) {
 	if len(coefficients) == 0 {
-		return nil, errors.Errorf("no coefficients given")
+		return nil, fmt.Errorf("no coefficients given")
 	}
 	for i, v := range coefficients {
 		if v.Sign() < 0 {
-			return nil, errors.Errorf("coefficient %d is negative (%d)", i, v)
+			return nil, fmt.Errorf("coefficient %d is negative (%d)", i, v)
 		}
 		if v.Cmp(bn256.Order) >= 0 {
-			return nil, errors.Errorf("coefficient %d is too big (%d)", i, v)
+			return nil, fmt.Errorf("coefficient %d is too big (%d)", i, v)
 		}
 	}
 	p := Polynomial(coefficients)
@@ -211,7 +211,7 @@ func RandomPolynomial(r io.Reader, degree uint64) (*Polynomial, error) {
 	for i := uint64(0); i < degree+1; i++ {
 		c, err := rand.Int(r, bn256.Order)
 		if err != nil {
-			return nil, errors.WithStack(err)
+			return nil, err
 		}
 		coefficients = append(coefficients, c)
 	}

--- a/shlib/shcrypto/feldman.go
+++ b/shlib/shcrypto/feldman.go
@@ -8,7 +8,6 @@ import (
 	"math/big"
 
 	bn256 "github.com/ethereum/go-ethereum/crypto/bn256/cloudflare"
-	gocmp "github.com/google/go-cmp/cmp"
 )
 
 var (
@@ -175,8 +174,6 @@ func EqualG1(p1, p2 *bn256.G1) bool {
 	return bytes.Equal(p1Bytes, p2Bytes)
 }
 
-var G1Comparer = gocmp.Comparer(EqualG1)
-
 // EqualG2 checks if two points on G2 are equal.
 func EqualG2(p1, p2 *bn256.G2) bool {
 	p1Bytes := new(bn256.G2).Set(p1).Marshal()
@@ -184,16 +181,12 @@ func EqualG2(p1, p2 *bn256.G2) bool {
 	return bytes.Equal(p1Bytes, p2Bytes)
 }
 
-var G2Comparer = gocmp.Comparer(EqualG2)
-
 // EqualGT checks if two points on GT are equal.
 func EqualGT(p1, p2 *bn256.GT) bool {
 	p1Bytes := new(bn256.GT).Set(p1).Marshal()
 	p2Bytes := new(bn256.GT).Set(p2).Marshal()
 	return bytes.Equal(p1Bytes, p2Bytes)
 }
-
-var GTComparer = gocmp.Comparer(EqualGT)
 
 // VerifyPolyEval checks that the evaluation of a polynomial is consistent with the public gammas.
 func VerifyPolyEval(keyperIndex int, polyEval *big.Int, gammas *Gammas, threshold uint64) bool {

--- a/shlib/shcrypto/feldman_test.go
+++ b/shlib/shcrypto/feldman_test.go
@@ -131,7 +131,7 @@ func TestZeroGammas(t *testing.T) {
 	g := ZeroGammas(uint64(3))
 	assert.Equal(t, 4, len(*g))
 	for _, p := range *g {
-		assert.DeepEqual(t, p, zeroG2, G2Comparer)
+		assert.DeepEqual(t, p, zeroG2, g2Comparer)
 	}
 }
 
@@ -171,8 +171,8 @@ func TestPi(t *testing.T) {
 	pi2Exp := new(bn256.G2).Add(g1, new(bn256.G2).ScalarMult(g2, big.NewInt(2)))
 	pi2Exp = new(bn256.G2).Add(pi2Exp, new(bn256.G2).ScalarMult(g3, big.NewInt(4)))
 
-	assert.DeepEqual(t, pi1, pi1Exp, G2Comparer)
-	assert.DeepEqual(t, pi2, pi2Exp, G2Comparer)
+	assert.DeepEqual(t, pi1, pi1Exp, g2Comparer)
+	assert.DeepEqual(t, pi2, pi2Exp, g2Comparer)
 }
 
 func TestGammasGobable(t *testing.T) {

--- a/shlib/shcrypto/gob_test.go
+++ b/shlib/shcrypto/gob_test.go
@@ -36,5 +36,5 @@ func TestEpochSecretKeyShareGobable(t *testing.T) {
 
 func TestEpochSecretKeyGobable(t *testing.T) {
 	key := (*EpochSecretKey)(new(bn256.G1).ScalarBaseMult(big.NewInt(1111)))
-	shtest.EnsureGobable(t, key, new(EpochSecretKey), G1Comparer)
+	shtest.EnsureGobable(t, key, new(EpochSecretKey), g1Comparer)
 }

--- a/shlib/shcrypto/hash.go
+++ b/shlib/shcrypto/hash.go
@@ -1,0 +1,39 @@
+package shcrypto
+
+import (
+	"math/big"
+
+	bn256 "github.com/ethereum/go-ethereum/crypto/bn256/cloudflare"
+	"golang.org/x/crypto/sha3"
+)
+
+func keccak256(ds ...[]byte) []byte {
+	state := sha3.NewLegacyKeccak256()
+	for _, d := range ds {
+		state.Write(d)
+	}
+	h := []byte{}
+	return state.Sum(h)
+}
+
+// HashBytesToBlock hashes the given byte slice and returns the result as a block.
+func HashBytesToBlock(ds ...[]byte) Block {
+	h := keccak256(ds...)
+	var b Block
+	copy(b[:], h)
+	return b
+}
+
+// HashBlockToInt hashes a block and returns the result as an integer in Z_q.
+func HashBlockToInt(d Block) *big.Int {
+	h := keccak256(d[:])
+	i := new(big.Int).SetBytes(h)
+	i.Mod(i, bn256.Order) // TODO: check if this is fine
+	return i
+}
+
+// HashGTToBlock hashes an element of GT and returns the result as a block.
+func HashGTToBlock(gt *bn256.GT) Block {
+	b := gt.Marshal()
+	return HashBytesToBlock(b)
+}

--- a/shlib/shcrypto/helpers_test.go
+++ b/shlib/shcrypto/helpers_test.go
@@ -1,0 +1,8 @@
+package shcrypto
+
+import gocmp "github.com/google/go-cmp/cmp"
+
+var (
+	g1Comparer = gocmp.Comparer(EqualG1)
+	g2Comparer = gocmp.Comparer(EqualG2)
+)

--- a/shlib/shcrypto/keys.go
+++ b/shlib/shcrypto/keys.go
@@ -3,10 +3,10 @@ package shcrypto
 import (
 	"bytes"
 	"crypto/rand"
+	"fmt"
 	"math/big"
 
 	bn256 "github.com/ethereum/go-ethereum/crypto/bn256/cloudflare"
-	"github.com/pkg/errors"
 )
 
 // EonSecretKeyShare represents a share of the eon secret key.
@@ -151,10 +151,10 @@ func ComputeEpochID(epochIndex uint64) *EpochID {
 // ComputeEpochSecretKey computes the epoch secret key from a set of shares.
 func ComputeEpochSecretKey(keyperIndices []int, epochSecretKeyShares []*EpochSecretKeyShare, threshold uint64) (*EpochSecretKey, error) {
 	if len(keyperIndices) != len(epochSecretKeyShares) {
-		return nil, errors.Errorf("got %d keyper indices, but %d secret shares", len(keyperIndices), len(epochSecretKeyShares))
+		return nil, fmt.Errorf("got %d keyper indices, but %d secret shares", len(keyperIndices), len(epochSecretKeyShares))
 	}
 	if uint64(len(keyperIndices)) != threshold {
-		return nil, errors.Errorf("got %d shares, but threshold is %d", len(keyperIndices), threshold)
+		return nil, fmt.Errorf("got %d shares, but threshold is %d", len(keyperIndices), threshold)
 	}
 
 	skG1 := new(bn256.G1).Set(zeroG1)

--- a/shlib/shcrypto/keys_test.go
+++ b/shlib/shcrypto/keys_test.go
@@ -73,9 +73,9 @@ func TestEonPublicKeyShare(t *testing.T) {
 	pks2 := new(bn256.G2).Add(mu20, mu21)
 	pks2.Add(pks2, mu22)
 
-	assert.DeepEqual(t, pks0, (*bn256.G2)(ComputeEonPublicKeyShare(0, gammas)), G2Comparer)
-	assert.DeepEqual(t, pks1, (*bn256.G2)(ComputeEonPublicKeyShare(1, gammas)), G2Comparer)
-	assert.DeepEqual(t, pks2, (*bn256.G2)(ComputeEonPublicKeyShare(2, gammas)), G2Comparer)
+	assert.DeepEqual(t, pks0, (*bn256.G2)(ComputeEonPublicKeyShare(0, gammas)), g2Comparer)
+	assert.DeepEqual(t, pks1, (*bn256.G2)(ComputeEonPublicKeyShare(1, gammas)), g2Comparer)
+	assert.DeepEqual(t, pks2, (*bn256.G2)(ComputeEonPublicKeyShare(2, gammas)), g2Comparer)
 }
 
 func TestEonSharesMatch(t *testing.T) {
@@ -122,7 +122,7 @@ func TestEonSharesMatch(t *testing.T) {
 
 func TestEonPublicKey(t *testing.T) {
 	zeroEPK := ComputeEonPublicKey([]*Gammas{})
-	assert.DeepEqual(t, (*bn256.G2)(zeroEPK), zeroG2, G2Comparer)
+	assert.DeepEqual(t, (*bn256.G2)(zeroEPK), zeroG2, g2Comparer)
 
 	threshold := uint64(2)
 	p1, err := RandomPolynomial(rand.Reader, threshold)
@@ -133,11 +133,11 @@ func TestEonPublicKey(t *testing.T) {
 	assert.NilError(t, err)
 
 	k1 := ComputeEonPublicKey([]*Gammas{p1.Gammas()})
-	assert.DeepEqual(t, (*bn256.G2)(k1), []*bn256.G2(*p1.Gammas())[0], G2Comparer)
+	assert.DeepEqual(t, (*bn256.G2)(k1), []*bn256.G2(*p1.Gammas())[0], g2Comparer)
 	k2 := ComputeEonPublicKey([]*Gammas{p2.Gammas()})
-	assert.DeepEqual(t, (*bn256.G2)(k2), []*bn256.G2(*p2.Gammas())[0], G2Comparer)
+	assert.DeepEqual(t, (*bn256.G2)(k2), []*bn256.G2(*p2.Gammas())[0], g2Comparer)
 	k3 := ComputeEonPublicKey([]*Gammas{p3.Gammas()})
-	assert.DeepEqual(t, (*bn256.G2)(k3), []*bn256.G2(*p3.Gammas())[0], G2Comparer)
+	assert.DeepEqual(t, (*bn256.G2)(k3), []*bn256.G2(*p3.Gammas())[0], g2Comparer)
 }
 
 func TestEonPublicKeyMatchesSecretKey(t *testing.T) {
@@ -157,7 +157,7 @@ func TestEonPublicKeyMatchesSecretKey(t *testing.T) {
 
 	gammas := []*Gammas{p1.Gammas(), p2.Gammas(), p3.Gammas()}
 	epk := ComputeEonPublicKey(gammas)
-	assert.DeepEqual(t, (*bn256.G2)(epk), epkExp, G2Comparer)
+	assert.DeepEqual(t, (*bn256.G2)(epk), epkExp, g2Comparer)
 }
 
 var modbn256Comparer = gocmp.Comparer(func(x, y *big.Int) bool {
@@ -268,7 +268,7 @@ func TestComputeEpochSecretKeyShare(t *testing.T) {
 	epochID := ComputeEpochID(uint64(456))
 	epochSecretKeyShare := ComputeEpochSecretKeyShare(eonSecretKeyShare, epochID)
 	expectedEpochSecretKeyShare := new(bn256.G1).ScalarMult((*bn256.G1)(epochID), (*big.Int)(eonSecretKeyShare))
-	assert.DeepEqual(t, expectedEpochSecretKeyShare, (*bn256.G1)(epochSecretKeyShare), G1Comparer)
+	assert.DeepEqual(t, expectedEpochSecretKeyShare, (*bn256.G1)(epochSecretKeyShare), g1Comparer)
 }
 
 func TestVerifyEpochSecretKeyShare(t *testing.T) {

--- a/shlib/shcrypto/shuffle.go
+++ b/shlib/shcrypto/shuffle.go
@@ -4,14 +4,13 @@ import (
 	"encoding/binary"
 	"math/rand"
 
-	"github.com/ethereum/go-ethereum/crypto"
 	bn256 "github.com/ethereum/go-ethereum/crypto/bn256/cloudflare"
 )
 
 // computeSeed computes a seed value from the EpochSecretKey.
 func computeSeed(key *EpochSecretKey) int64 {
 	keyBytes := (*bn256.G1)(key).Marshal()
-	keyHash := crypto.Keccak256(keyBytes)
+	keyHash := keccak256(keyBytes)
 	return int64(binary.LittleEndian.Uint64(keyHash[:8]))
 }
 

--- a/shuttermint/shmsg/extend_test.go
+++ b/shuttermint/shmsg/extend_test.go
@@ -45,7 +45,7 @@ func TestG1Marshal(t *testing.T) {
 	assert.NilError(t, err)
 	ug, err := umsg.Get()
 	assert.NilError(t, err)
-	assert.DeepEqual(t, g, ug, shcrypto.G1Comparer)
+	assert.Check(t, shcrypto.EqualG1(g, ug))
 }
 
 func TestG2Marshal(t *testing.T) {
@@ -60,7 +60,7 @@ func TestG2Marshal(t *testing.T) {
 	assert.NilError(t, err)
 	ug, err := umsg.Get()
 	assert.NilError(t, err)
-	assert.DeepEqual(t, g, ug, shcrypto.G2Comparer)
+	assert.Check(t, shcrypto.EqualG2(g, ug))
 }
 
 func TestGTMarshal(t *testing.T) {
@@ -75,5 +75,5 @@ func TestGTMarshal(t *testing.T) {
 	assert.NilError(t, err)
 	ug, err := umsg.Get()
 	assert.NilError(t, err)
-	assert.DeepEqual(t, g, ug, shcrypto.GTComparer)
+	assert.Check(t, shcrypto.EqualGT(g, ug))
 }


### PR DESCRIPTION
The following dependencies are removed:

- `go-ethereum` (only used for hashing, replaced by using `crypto/sha3` directly)
- `pkg/errors` (replaced by `errors`)
- `go-cmp` (comparators moved to a `helpers_test.go` so that we can still use them in tests, replaced by normal equality checks externally)