### PR TITLE
Add build step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,13 @@ following command replicates these settings:
 ganache-cli -d -b 3
 ```
 
-### 2) Deploy the Shutter Contracts:
+### 2) Build Shutter and deploy the Shutter Contracts:
+
+If you use the source release or git repository, you need to build the shuttermint application:
+```
+cd shuttermint
+make build
+```
 
 Next, the Shutter contract suite has to be deployed on the dev chain:
 


### PR DESCRIPTION
Instructions were unclear, without this.