### PR TITLE
Implement TestKeyGen

### DIFF
--- a/shlib/shcrypto/testkeygen.go
+++ b/shlib/shcrypto/testkeygen.go
@@ -1,0 +1,74 @@
+package shcrypto
+
+import (
+	"crypto/rand"
+	"math/big"
+)
+
+type TestKeyGen struct {
+	n                  uint64
+	threshold          uint64
+	polynomials        []*Polynomial
+	eonSecretKeyShares []*EonSecretKeyShare
+
+	EonPublicKey *EonPublicKey
+}
+
+func NewTestKeyGen() (*TestKeyGen, error) {
+	n := 3
+	threshold := uint64(2)
+
+	polynomials := []*Polynomial{}
+	gammas := []*Gammas{}
+	for i := 0; i < n; i++ {
+		p, err := RandomPolynomial(rand.Reader, threshold-1)
+		if err != nil {
+			return nil, err
+		}
+		polynomials = append(polynomials, p)
+		gammas = append(gammas, p.Gammas())
+
+	}
+	eonPublicKey := ComputeEonPublicKey(gammas)
+
+	eonSecretKeyShares := []*EonSecretKeyShare{}
+	for i := 0; i < n; i++ {
+		ss := []*big.Int{}
+		for j := 0; j < n; j++ {
+			s := polynomials[j].EvalForKeyper(i)
+			ss = append(ss, s)
+		}
+		eonSecretKeyShare := ComputeEonSecretKeyShare(ss)
+		eonSecretKeyShares = append(eonSecretKeyShares, eonSecretKeyShare)
+	}
+
+	return &TestKeyGen{
+		n:                  uint64(n),
+		threshold:          threshold,
+		polynomials:        polynomials,
+		eonSecretKeyShares: eonSecretKeyShares,
+
+		EonPublicKey: eonPublicKey,
+	}, nil
+}
+
+func (g *TestKeyGen) ComputeEpochSecretKey(epochID *EpochID) (*EpochSecretKey, error) {
+	indices := []int{}
+	epochSecretKeyShares := []*EpochSecretKeyShare{}
+	for i := 0; i < int(g.threshold); i++ {
+		ss := []*big.Int{}
+		for j := 0; j < int(g.n); j++ {
+			s := g.polynomials[j].EvalForKeyper(i)
+			ss = append(ss, s)
+		}
+		epochSecretKeyShare := ComputeEpochSecretKeyShare(g.eonSecretKeyShares[i], epochID)
+
+		indices = append(indices, i)
+		epochSecretKeyShares = append(epochSecretKeyShares, epochSecretKeyShare)
+	}
+	return ComputeEpochSecretKey(
+		indices,
+		epochSecretKeyShares,
+		g.threshold,
+	)
+}

--- a/shlib/shcrypto/testkeygen_test.go
+++ b/shlib/shcrypto/testkeygen_test.go
@@ -1,0 +1,21 @@
+package shcrypto
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestTestKeyGen(t *testing.T) {
+	g, err := NewTestKeyGen()
+	assert.NilError(t, err)
+
+	epochIDBytes := []byte("epochid")
+	epochID := ComputeEpochID(epochIDBytes)
+	epochSecretKey, err := g.ComputeEpochSecretKey(epochID)
+	assert.NilError(t, err)
+
+	ok, err := VerifyEpochSecretKey(epochSecretKey, g.EonPublicKey, epochIDBytes)
+	assert.NilError(t, err)
+	assert.Assert(t, ok)
+}


### PR DESCRIPTION
This adds a helper to create an eon key and corresponding decryption keys in a straightforward manner. It's intended for tests. The logic is derived from `makeKeys` in `encryption_test.go`