### PR TITLE
Add encoding function for gammas

### DIFF
--- a/shlib/shcrypto/encoding_test.go
+++ b/shlib/shcrypto/encoding_test.go
@@ -5,6 +5,8 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
+	blst "github.com/supranational/blst/bindings/go"
 	"gotest.tools/v3/assert"
 )
 
@@ -93,4 +95,49 @@ func TestIdentifyVersion(t *testing.T) {
 	// legacy version
 	assert.Assert(t, IdentifyVersion(d[1:]) != VersionIdentifier)
 	assert.Assert(t, IdentifyVersion(d[1:]) == 0x00)
+}
+
+func TestMarshalGammasEmpty(t *testing.T) {
+	g := &Gammas{}
+	m := g.Marshal()
+	assert.Assert(t, len(m) == 0)
+}
+
+func TestMarshalGammasError(t *testing.T) {
+	validGammaEncoding := makeTestG2(1).Compress()
+	inputs := [][]byte{
+		{0x00},
+		bytes.Repeat([]byte{0xaa}, 96),
+		common.FromHex(
+			"87f481803120be4e565dc88cdbb1ae4c1ddfa249bd34cdc43982d926278535e84ee584aa9ae3553f56d02d3aa842b3941058f0dcabacbc551dca1d04ba7647c806acf7f960809438993359338dc4858aadcbce50f9a370986c74053303ab4449",
+		),
+		validGammaEncoding[:len(validGammaEncoding)-1],
+		append([]byte{0x00}, validGammaEncoding...),
+	}
+	for _, input := range inputs {
+		g := &Gammas{}
+		err := g.Unmarshal(input)
+		assert.Assert(t, err != nil)
+	}
+}
+
+func TestMarshalGammasRoundtrip(t *testing.T) {
+	gammaValues := []*Gammas{
+		{},
+		{makeTestG2(1)},
+		{makeTestG2(2), makeTestG2(2), makeTestG2(3), makeTestG2(4), makeTestG2(5), makeTestG2(6)},
+	}
+	for _, gammas := range gammaValues {
+		m := gammas.Marshal()
+		assert.Assert(t, len(m) == len([]*blst.P2Affine(*gammas))*96)
+		g := &Gammas{}
+		assert.NilError(t, g.Unmarshal(m))
+		assert.DeepEqual(t, gammas, g, g2Comparer)
+
+		mText, err := gammas.MarshalText()
+		assert.NilError(t, err)
+		gText := &Gammas{}
+		assert.NilError(t, gText.UnmarshalText(mText))
+		assert.DeepEqual(t, gammas, gText, g2Comparer)
+	}
 }


### PR DESCRIPTION
At the moment, we implement this in rolling shutter manually, see eg [here](https://github.com/shutter-network/rolling-shutter/blob/25c816f235666b19c0d7431cb8f9e0dc486e391e/rolling-shutter/shmsg/messages.go#L82-L85) and [here](https://github.com/shutter-network/rolling-shutter/blob/25c816f235666b19c0d7431cb8f9e0dc486e391e/rolling-shutter/keyper/shutterevents/marshal.go#L98-L124). This requires it to know about the internal representation of `Gammas` which is undesirable. Here we implement an encoding and corresponding decoding function.

Builds on top of #122 