### PR TITLE
Update the version prefix

### DIFF
--- a/shlib/shcrypto/version.go
+++ b/shlib/shcrypto/version.go
@@ -1,6 +1,6 @@
 package shcrypto
 
-const VersionIdentifier byte = 0x02
+const VersionIdentifier byte = 0x03
 
 // IdentifyVersion reads the version identifier byte from the given (marshaled) EncryptedMessage.
 func IdentifyVersion(d []byte) byte {


### PR DESCRIPTION
Update the encrypted message version prefix to 3 because of the recent switch to BLST and the change of `Hash1`.